### PR TITLE
Filter apps by pixel policy

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/.vtexignore
+++ b/.vtexignore
@@ -14,3 +14,4 @@ react/__tests__/**
 react/.babelrc
 react/.eslintrc
 react/setupTests.ts
+react/jest.config.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Filter apps by `pixel` policy.
 
 ## [0.3.1] - 2019-03-12
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.4.0] - 2019-03-13
 ### Changed
 - Filter apps by `pixel` policy.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "pixel-manager",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "title": "VTEX Pixel Manager",
   "description": "The VTEX Pixel Manager App.",
   "builders": {

--- a/node/resolvers/pixel.ts
+++ b/node/resolvers/pixel.ts
@@ -1,3 +1,4 @@
+import { nth, zip } from 'ramda'
 import { Apps, LRUCache } from '@vtex/api'
 
 import { getAppMajor } from '../utils/conf'
@@ -10,25 +11,28 @@ const cacheStorage = new LRUCache<string, any>({
   maxAge: RESPONSE_CACHE_TTL_MS,
 })
 
-// This exists because we use the apps who depend on us
-// to figure out who to add to the page inside an iframe,
-// but the apps bellow also depends on this app and we
-// don't want to package them inside an iframe too, so
-// this whitelist is used to decide who won't be.
-const APP_WHITELIST = [
-  'vtex.store',
-  'vtex.store-components',
-]
-
 export const queries = {
   installedPixels: async (_, __, { vtex }) => {
-    const opts = {cacheStorage}
-    const withLongTimeout = {...opts, timeout: LONG_TIMEOUT}
+    const opts = { cacheStorage }
+    const withLongTimeout = { ...opts, timeout: LONG_TIMEOUT }
 
     const apps = new Apps(vtex, withLongTimeout)
 
-    const deps = await apps.getDependencies(`vtex.pixel-manager@${getAppMajor()}.x`)
+    const deps = await apps.getDependencies(
+      `vtex.pixel-manager@${getAppMajor()}.x`
+    )
+    const manifests = await Promise.all(
+      Object.keys(deps).map(appId => apps.getApp(appId))
+    )
 
-    return Object.keys(deps).filter(appId => !APP_WHITELIST.includes(appId.split('@')[0]))
+    return Promise.all(
+      zip(Object.keys(deps), manifests)
+        .filter(
+          ([_, manifest]) =>
+            manifest.policies &&
+            manifest.policies.findIndex(({ name }) => name === 'pixel') !== -1
+        )
+        .map(nth(0))
+    )
   },
 }

--- a/node/resolvers/pixel.ts
+++ b/node/resolvers/pixel.ts
@@ -1,4 +1,4 @@
-import { nth, zip } from 'ramda'
+import { nth, zip, prop, map } from 'ramda'
 import { Apps, LRUCache } from '@vtex/api'
 
 import { getAppMajor } from '../utils/conf'
@@ -27,10 +27,8 @@ export const queries = {
 
     return Promise.all(
       zip(Object.keys(deps), manifests)
-        .filter(
-          ([_, manifest]) =>
-            manifest.policies &&
-            manifest.policies.findIndex(({ name }) => name === 'pixel') !== -1
+        .filter(([_, manifest]) =>
+          map(prop('name'), manifest.policies || []).includes('pixel')
         )
         .map(nth(0))
     )


### PR DESCRIPTION
#### What is the purpose of this pull request?
Filter apps to be inserted into iframe by policy, instead of relying purely on the dependency on `vtex.pixel-manager`.

#### What problem is this solving?
Everytime you needed to add support for an app to send events to the pixel, you needed to add the app name to a whitelist hardcoded in the resolver, because otherwise it would be inserted into an iframe and would generate all sorts of errors in the console.

Now, when you are developing a pixel app, you need to specify both the dependency on the `vtex.pixel-manager` and add the policy with name `"pixel"`.

#### How should this be manually tested?
[This workspace](https://lucas--storecomponents.myvtex.com/).

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
