### PR TITLE
Add google-analytics to sandbox whitelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Added `gocommerce.google-analytics` to sandbox whitelist.
 
 ## [0.4.0] - 2019-03-13
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.5.0] - 2019-03-18
 ### Changed
 - Added `gocommerce.google-analytics` to sandbox whitelist.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "pixel-manager",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "title": "VTEX Pixel Manager",
   "description": "The VTEX Pixel Manager App.",
   "builders": {

--- a/react/PixelIFrame.tsx
+++ b/react/PixelIFrame.tsx
@@ -11,6 +11,7 @@ interface Props {
 // access and are trusted.
 const WHITELIST = [
   'vtex.request-capture',
+  'gocommerce.google-analytics',
 ]
 
 const sendEvent = (frameWindow: Window, data: PixelData) => {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add gocommerce google analytics app to the sandbox whitelist.

#### What problem is this solving?
The analytics needs special access to some window properties, and it's not possible for a user to leverage this app to inject arbitrary scripts in the window, so I think we're fine.

#### How should this be manually tested?
[Workspace](https://lucas--storecomponents.myvtex.com/).

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
