### PR TITLE
Add new event type: productClick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.7.0] - 2019-05-02
 ### Added
 - Added new type of event, productClick.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added new type of event, productClick.
 
 ## [0.6.0] - 2019-03-21
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "pixel-manager",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "title": "VTEX Pixel Manager",
   "description": "The VTEX Pixel Manager App.",
   "builders": {

--- a/react/PixelContext.tsx
+++ b/react/PixelContext.tsx
@@ -6,6 +6,7 @@ const SUBSCRIPTION_TIMEOUT = 100
 type EventType =
   | 'homeView'
   | 'productView'
+  | 'productClick'
   | 'otherView'
   | 'categoryView'
   | 'departmentView'

--- a/react/PixelIFrame.tsx
+++ b/react/PixelIFrame.tsx
@@ -53,6 +53,7 @@ const PixelIFrame: React.FunctionComponent<Props> = ({ pixel }) => {
       pageInfo: pixelEventHandler('pageInfo'),
       pageView: pixelEventHandler('pageView'),
       productView: pixelEventHandler('productView'),
+      productClick: pixelEventHandler('productClick'),
       removeFromCart: pixelEventHandler('removeFromCart'),
       pageComponentInteraction: pixelEventHandler('pageComponentInteraction'),
     })


### PR DESCRIPTION
#### What problem is this solving?
In order to send events to google analytics, this pr create a new pixel event type, the product click, because there is a semantic differentiation between product view and product click events. 

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [X] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
