### PR TITLE
Fix race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.2] - 2019-05-09
+
 ## [0.11.2-beta] - 2019-05-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix another race condition
+
 ## [0.11.1] - 2019-05-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.2-beta] - 2019-05-09
+
 ### Fixed
 
 - Fix another race condition

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "pixel-manager",
-  "version": "0.11.1",
+  "version": "0.11.2-beta",
   "title": "VTEX Pixel Manager",
   "description": "The VTEX Pixel Manager App.",
   "builders": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "pixel-manager",
-  "version": "0.11.2-beta",
+  "version": "0.11.2",
   "title": "VTEX Pixel Manager",
   "description": "The VTEX Pixel Manager App.",
   "builders": {


### PR DESCRIPTION
Our first fix solved the issue of the pixels subscribing before the iframe was loaded. Since the iframe was not loaded, the events were being triggered before the JS of the iframe was listening to events, making the iframe missing those events.

Now, the issue is: the events were being triggered *before* the pixel could even start subscribing. This made those events to be lost as well.

The current solution keeps all the first 7 seconds of triggered events in a variable that could be retrieved by the PixelIFrame once it loads.

https://googleanalytics--storecomponents.myvtex.com/traveler-backpack/p

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
