### PR TITLE
Allowed pixel iframe read parent cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Allowed pixel iframe read parent cookies.
+- Allow pixel iframe to read parent cookies.
 
 ## [0.11.3] - 2019-05-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allowed pixel iframe read parent cookies.
+
 ## [0.11.3] - 2019-05-14
 
 ### Fixed
@@ -19,11 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix another race condition
+- Fix another race condition.
 
 ## [0.11.1] - 2019-05-09
 
 ### Fixed
+
 - Export `usePixel` in `PixelContext`.
 
 ## [0.11.0] - 2019-05-09

--- a/react/PixelIFrame.tsx
+++ b/react/PixelIFrame.tsx
@@ -101,9 +101,9 @@ const PixelIFrame: React.FunctionComponent<Props> = ({ pixel }) => {
   const [appName] = pixel.split('@')
 
   const iframePolicy =
-    'allow-same-origin' + isWhitelisted(appName, account)
-      ? undefined
-      : 'allow-scripts'
+    'allow-same-origin ' + isWhitelisted(appName, account)
+      ? 'allow-scripts'
+      : undefined
 
   return (
     <iframe

--- a/react/PixelIFrame.tsx
+++ b/react/PixelIFrame.tsx
@@ -9,11 +9,7 @@ interface Props {
 
 // internal: the apps bellow need special
 // access and are trusted.
-const WHITELIST = [
-  'vtex.request-capture',
-  'gocommerce.google-analytics',
-  'vtex.google-analytics',
-]
+const WHITELIST = ['vtex.request-capture']
 
 const ACCOUNT_WHITELIST = ['boticario']
 
@@ -104,12 +100,17 @@ const PixelIFrame: React.FunctionComponent<Props> = ({ pixel }) => {
 
   const [appName] = pixel.split('@')
 
+  const iframePolicy =
+    'allow-same-origin' + isWhitelisted(appName, account)
+      ? undefined
+      : 'allow-scripts'
+
   return (
     <iframe
       title={pixel}
       hidden
       onLoad={onLoad}
-      sandbox={isWhitelisted(appName, account) ? undefined : 'allow-scripts'}
+      sandbox={iframePolicy}
       src={`/_v/public/tracking-frame/${pixel}`}
       ref={frame}
     />


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Add a new policy called `allow-same-origin` in sandbox property of pixel iframe. 

To understand more about this policy, check here: https://www.html5rocks.com/en/tutorials/security/sandboxed-iframes/

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Fix  the problem below when ga needs to access `document.cookie`

![image](https://user-images.githubusercontent.com/8000984/57744887-63577900-76a1-11e9-94e1-cc9f79db9ff8.png)

#### How should this be manually tested?
workspace with the problem: https://breno--ecowaterqa.myvtexdev.com/
workspace with the solution: https://cookies--ecowaterqa.myvtexdev.com/

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
