### PR TITLE
Make iframes render in a different origin and remove sandbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,6 @@ npm-debug.log
 .build/
 lib
 *.orig
+.vscode
 
 package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Usage of cookies by iframes.
+
 ## [0.12.0] - 2019-05-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1] - 2019-05-20
+
 ### Fixed
 
 - Usage of cookies by iframes.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "pixel-manager",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "title": "VTEX Pixel Manager",
   "description": "The VTEX Pixel Manager App.",
   "builders": {

--- a/node/handlers/pixelFrame.ts
+++ b/node/handlers/pixelFrame.ts
@@ -28,7 +28,8 @@ const pixelFrame = async (ctx: ServiceContext, next: () => Promise<any>) => {
   if (!isLinked) {
     ctx.set('Cache-Control', `public, max-age=${CACHE_2_MINUTES}`)
   }
-  ctx.body = html({ scripts, settings })
+
+  ctx.body = html({ appId, scripts, settings })
 
   await next()
 }

--- a/node/templates.ts
+++ b/node/templates.ts
@@ -1,6 +1,7 @@
 import { map } from 'ramda'
 
 interface TemplateInput {
+  appId: string
   scripts?: string[]
   settings: {
     [varName: string]: any
@@ -9,14 +10,22 @@ interface TemplateInput {
 
 const scriptSrcToTag = (src: string) => `<script src="${src}" defer></script>`
 
-export const html = ({ settings = {}, scripts = [] }: TemplateInput) => `<!DOCTYPE html>
+export const html = ({ appId, settings = {}, scripts = [] }: TemplateInput) => `<!DOCTYPE html>
 <html>
 <head>
-  ${map(scriptSrcToTag, scripts).join('\n')}
+  ${map(scriptSrcToTag, scripts).join('\n  ')}
   <script>
     window.__SETTINGS__ = ${JSON.stringify(settings)};
   </script>
 </head>
 <body>
+
+<script>
+  (function() {
+    window.addEventListener('load', function() {
+      window.parent.postMessage('pixel:ready:${appId}', '*');
+    })
+  })()
+</script>
 </body>
 </html>`

--- a/node/templates.ts
+++ b/node/templates.ts
@@ -22,9 +22,18 @@ export const html = ({ appId, settings = {}, scripts = [] }: TemplateInput) => `
 
 <script>
   (function() {
-    window.addEventListener('load', function() {
+    function triggerReady() {
       window.parent.postMessage('pixel:ready:${appId}', '*');
-    })
+    }
+    function listener(event) {
+      if (event.data === 'pixel:listening') {
+        triggerReady();
+        window.removeEventListener('message', listener);
+      }
+    }
+
+    window.addEventListener('message', listener, false);
+    window.addEventListener('load', triggerReady)
   })()
 </script>
 </body>

--- a/node/templates.ts
+++ b/node/templates.ts
@@ -25,8 +25,12 @@ export const html = ({ appId, settings = {}, scripts = [] }: TemplateInput) => `
     function triggerReady() {
       window.parent.postMessage('pixel:ready:${appId}', '*');
     }
-    function listener(event) {
-      if (event.data === 'pixel:listening') {
+    function listener(message) {
+      if (
+        message.data &&
+        message.data.event === 'pixel:listening' &&
+        message.data.pixel === '${appId}'
+      ) {
         triggerReady();
         window.removeEventListener('message', listener);
       }

--- a/react/PixelIFrame.tsx
+++ b/react/PixelIFrame.tsx
@@ -1,10 +1,4 @@
-import React, {
-  memo,
-  useRef,
-  useEffect,
-  useState,
-  useCallback,
-} from 'react'
+import React, { memo, useRef, useEffect, useState, useCallback } from 'react'
 import { useRuntime } from 'vtex.render-runtime'
 import { PixelData, usePixel } from './PixelContext'
 import sendEvent from './modules/sendEvent'
@@ -64,6 +58,10 @@ const PixelIFrame: React.FunctionComponent<Props> = ({ pixel }) => {
   const [appName] = pixel.split('@')
 
   const onLoad = useCallback(() => {
+    if (isLoaded) {
+      return
+    }
+
     setLoadComplete(true)
 
     // If the effect already ran, we use ref, otherwise we use `getFirstEvents`
@@ -76,7 +74,7 @@ const PixelIFrame: React.FunctionComponent<Props> = ({ pixel }) => {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       sendEvent(frame.current!.contentWindow!, event)
     })
-  }, [currency, getFirstEvents, setLoadComplete])
+  }, [currency, getFirstEvents, setLoadComplete, isLoaded])
 
   const listenMessage = useCallback(
     (message: MessageEvent) => {

--- a/react/PixelIFrame.tsx
+++ b/react/PixelIFrame.tsx
@@ -7,6 +7,20 @@ interface Props {
   pixel: string
 }
 
+// internal: the apps bellow need special
+// access and are trusted.
+const WHITELIST = [
+  'vtex.request-capture',
+  'gocommerce.google-analytics',
+  'vtex.google-analytics',
+]
+
+const ACCOUNT_WHITELIST = ['boticario']
+
+const isWhitelisted = (app: string, accountName: string): boolean => {
+  return WHITELIST.includes(app) || ACCOUNT_WHITELIST.includes(accountName)
+}
+
 function enhanceEvent(event: PixelData, currency: string) {
   return {
     currency,
@@ -94,7 +108,10 @@ const PixelIFrame: React.FunctionComponent<Props> = ({ pixel }) => {
     <iframe
       title={pixel}
       hidden
-      onLoad={onLoad}
+      {...(isWhitelisted(appName, account)
+        ? { sandbox: 'allow-scripts allow-same-origin' }
+        : {}
+      )}
       src={`https://${workspace}--${account}.myvtex.com/_v/public/tracking-frame/${pixel}`}
       ref={frame}
     />

--- a/react/PixelIFrame.tsx
+++ b/react/PixelIFrame.tsx
@@ -7,20 +7,6 @@ interface Props {
   pixel: string
 }
 
-// internal: the apps bellow need special
-// access and are trusted.
-const WHITELIST = [
-  'vtex.request-capture',
-  'gocommerce.google-analytics',
-  'vtex.google-analytics',
-]
-
-const ACCOUNT_WHITELIST = ['boticario']
-
-const isWhitelisted = (app: string, accountName: string): boolean => {
-  return WHITELIST.includes(app) || ACCOUNT_WHITELIST.includes(accountName)
-}
-
 function enhanceEvent(event: PixelData, currency: string) {
   return {
     currency,
@@ -41,6 +27,7 @@ const PixelIFrame: React.FunctionComponent<Props> = ({ pixel }) => {
   const {
     culture: { currency },
     account,
+    workspace,
   } = useRuntime()
   const { subscribe, getFirstEvents } = usePixel()
 
@@ -103,15 +90,12 @@ const PixelIFrame: React.FunctionComponent<Props> = ({ pixel }) => {
     return () => unsubscribe()
   }, [currency, pixel, subscribe, isLoaded, getFirstEvents])
 
-  const [appName] = pixel.split('@')
-
   return (
     <iframe
       title={pixel}
       hidden
       onLoad={onLoad}
-      sandbox={isWhitelisted(appName, account) ? undefined : 'allow-scripts'}
-      src={`/_v/public/tracking-frame/${pixel}`}
+      src={`https://${workspace}--${account}.myvtex.com/_v/public/tracking-frame/${pixel}`}
       ref={frame}
     />
   )

--- a/react/PixelIFrame.tsx
+++ b/react/PixelIFrame.tsx
@@ -151,10 +151,11 @@ const PixelIFrame: React.FunctionComponent<Props> = ({ pixel }) => {
     <iframe
       title={pixel}
       hidden
-      {...(isWhitelisted(appName, account)
-        ? { sandbox: 'allow-scripts allow-same-origin' }
-        : {})}
-      src={`https://${workspace}--${account}.myvtex.com/_v/public/tracking-frame/${pixel}`}
+      src={
+        isWhitelisted(appName, account)
+          ? `/_v/public/tracking-frame/${pixel}`
+          : `https://${workspace}--${account}.myvtex.com/_v/public/tracking-frame/${pixel}`
+      }
       ref={frame}
     />
   )

--- a/react/PixelIFrame.tsx
+++ b/react/PixelIFrame.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useRef, useEffect, useState } from 'react'
+import React, { memo, useRef, useEffect, useState, useCallback } from 'react'
 import { useRuntime } from 'vtex.render-runtime'
 import { PixelData, usePixel } from './PixelContext'
 import sendEvent from './modules/sendEvent'
@@ -33,14 +33,14 @@ function enhanceFirstEvents(firstEvents: PixelData[], currency: string) {
   return firstEvents.map(e => enhanceEvent(e, currency))
 }
 
-function useMessageEvents(listener: (e: MessageEvent) => void, deps: any[]) {
+function useMessageEvents(listener: (e: MessageEvent) => void) {
   useEffect(() => {
     window.addEventListener('message', listener, false)
 
     return () => {
       window.removeEventListener('message', listener)
     }
-  }, deps)
+  }, [listener])
 }
 
 const PixelIFrame: React.FunctionComponent<Props> = ({ pixel }) => {
@@ -57,16 +57,16 @@ const PixelIFrame: React.FunctionComponent<Props> = ({ pixel }) => {
 
   const [appName] = pixel.split('@')
 
-  const listenMessage = (message: MessageEvent) => {
+  const listenMessage = useCallback((message: MessageEvent) => {
     const sameFrame = frame.current && frame.current.contentWindow === message.source
     const samePixel = message.data && message.data.indexOf && message.data.indexOf('pixel:ready:' + pixel) === 0
 
     if (sameFrame && samePixel) {
       onLoad()
     }
-  }
+  }, [pixel])
 
-  useMessageEvents(listenMessage, [pixel, frame.current])
+  useMessageEvents(listenMessage)
 
   const onLoad = () => {
     setLoadComplete(true)

--- a/react/PixelIFrame.tsx
+++ b/react/PixelIFrame.tsx
@@ -4,7 +4,6 @@ import React, {
   useEffect,
   useState,
   useCallback,
-  RefObject,
 } from 'react'
 import { useRuntime } from 'vtex.render-runtime'
 import { PixelData, usePixel } from './PixelContext'
@@ -40,24 +39,14 @@ function enhanceFirstEvents(firstEvents: PixelData[], currency: string) {
   return firstEvents.map(e => enhanceEvent(e, currency))
 }
 
-function useMessageEvents(
-  listener: (e: MessageEvent) => void,
-  pixel: string,
-  frame: RefObject<HTMLIFrameElement>
-) {
+function useMessageEvents(listener: (e: MessageEvent) => void) {
   useEffect(() => {
     window.addEventListener('message', listener, false)
-    if (frame.current && frame.current.contentWindow) {
-      sendEvent(frame.current.contentWindow, {
-        event: 'pixel:listening',
-        pixel,
-      })
-    }
 
     return () => {
       window.removeEventListener('message', listener)
     }
-  }, [listener, pixel])
+  }, [listener])
 }
 
 const PixelIFrame: React.FunctionComponent<Props> = ({ pixel }) => {
@@ -105,7 +94,16 @@ const PixelIFrame: React.FunctionComponent<Props> = ({ pixel }) => {
     [pixel, onLoad]
   )
 
-  useMessageEvents(listenMessage, pixel, frame)
+  useMessageEvents(listenMessage)
+
+  useEffect(() => {
+    if (frame.current && frame.current.contentWindow) {
+      sendEvent(frame.current.contentWindow, {
+        event: 'pixel:listening',
+        pixel,
+      })
+    }
+  }, [frame, pixel])
 
   useEffect(() => {
     const pixelEventHandler = (event: PixelData) => {

--- a/react/PixelIFrame.tsx
+++ b/react/PixelIFrame.tsx
@@ -42,18 +42,22 @@ function enhanceFirstEvents(firstEvents: PixelData[], currency: string) {
 
 function useMessageEvents(
   listener: (e: MessageEvent) => void,
+  pixel: string,
   frame: RefObject<HTMLIFrameElement>
 ) {
   useEffect(() => {
     window.addEventListener('message', listener, false)
     if (frame.current && frame.current.contentWindow) {
-      sendEvent(frame.current.contentWindow, { event: 'pixel:listening' })
+      sendEvent(frame.current.contentWindow, {
+        event: 'pixel:listening',
+        pixel,
+      })
     }
 
     return () => {
       window.removeEventListener('message', listener)
     }
-  }, [listener])
+  }, [listener, pixel])
 }
 
 const PixelIFrame: React.FunctionComponent<Props> = ({ pixel }) => {
@@ -101,7 +105,7 @@ const PixelIFrame: React.FunctionComponent<Props> = ({ pixel }) => {
     [pixel, onLoad]
   )
 
-  useMessageEvents(listenMessage, frame)
+  useMessageEvents(listenMessage, pixel, frame)
 
   useEffect(() => {
     const pixelEventHandler = (event: PixelData) => {

--- a/react/PixelIFrame.tsx
+++ b/react/PixelIFrame.tsx
@@ -1,4 +1,11 @@
-import React, { memo, useRef, useEffect, useState, useCallback } from 'react'
+import React, {
+  memo,
+  useRef,
+  useEffect,
+  useState,
+  useCallback,
+  RefObject,
+} from 'react'
 import { useRuntime } from 'vtex.render-runtime'
 import { PixelData, usePixel } from './PixelContext'
 import sendEvent from './modules/sendEvent'
@@ -33,9 +40,15 @@ function enhanceFirstEvents(firstEvents: PixelData[], currency: string) {
   return firstEvents.map(e => enhanceEvent(e, currency))
 }
 
-function useMessageEvents(listener: (e: MessageEvent) => void) {
+function useMessageEvents(
+  listener: (e: MessageEvent) => void,
+  frame: RefObject<HTMLIFrameElement>
+) {
   useEffect(() => {
     window.addEventListener('message', listener, false)
+    if (frame.current && frame.current.contentWindow) {
+      sendEvent(frame.current.contentWindow, { event: 'pixel:listening' })
+    }
 
     return () => {
       window.removeEventListener('message', listener)
@@ -88,7 +101,7 @@ const PixelIFrame: React.FunctionComponent<Props> = ({ pixel }) => {
     [pixel, onLoad]
   )
 
-  useMessageEvents(listenMessage)
+  useMessageEvents(listenMessage, frame)
 
   useEffect(() => {
     const pixelEventHandler = (event: PixelData) => {

--- a/react/PixelIFrame.tsx
+++ b/react/PixelIFrame.tsx
@@ -57,18 +57,7 @@ const PixelIFrame: React.FunctionComponent<Props> = ({ pixel }) => {
 
   const [appName] = pixel.split('@')
 
-  const listenMessage = useCallback((message: MessageEvent) => {
-    const sameFrame = frame.current && frame.current.contentWindow === message.source
-    const samePixel = message.data && message.data.indexOf && message.data.indexOf('pixel:ready:' + pixel) === 0
-
-    if (sameFrame && samePixel) {
-      onLoad()
-    }
-  }, [pixel])
-
-  useMessageEvents(listenMessage)
-
-  const onLoad = () => {
+  const onLoad = useCallback(() => {
     setLoadComplete(true)
 
     // If the effect already ran, we use ref, otherwise we use `getFirstEvents`
@@ -81,7 +70,25 @@ const PixelIFrame: React.FunctionComponent<Props> = ({ pixel }) => {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       sendEvent(frame.current!.contentWindow!, event)
     })
-  }
+  }, [currency, getFirstEvents, setLoadComplete])
+
+  const listenMessage = useCallback(
+    (message: MessageEvent) => {
+      const sameFrame =
+        frame.current && frame.current.contentWindow === message.source
+      const samePixel =
+        message.data &&
+        message.data.indexOf &&
+        message.data.indexOf('pixel:ready:' + pixel) === 0
+
+      if (sameFrame && samePixel) {
+        onLoad()
+      }
+    },
+    [pixel, onLoad]
+  )
+
+  useMessageEvents(listenMessage)
 
   useEffect(() => {
     const pixelEventHandler = (event: PixelData) => {
@@ -133,8 +140,7 @@ const PixelIFrame: React.FunctionComponent<Props> = ({ pixel }) => {
       hidden
       {...(isWhitelisted(appName, account)
         ? { sandbox: 'allow-scripts allow-same-origin' }
-        : {}
-      )}
+        : {})}
       src={`https://${workspace}--${account}.myvtex.com/_v/public/tracking-frame/${pixel}`}
       ref={frame}
     />

--- a/react/__mocks__/vtex.render-runtime/index.ts
+++ b/react/__mocks__/vtex.render-runtime/index.ts
@@ -1,4 +1,5 @@
 export const useRuntime = () => ({
   culture: { currency: 'BRL' },
   account: 'storecomponents',
+  workspace: 'master',
 })

--- a/react/__tests__/PixelIFrame.test.tsx
+++ b/react/__tests__/PixelIFrame.test.tsx
@@ -144,7 +144,9 @@ test('should trigger pixe:listening event', () => {
   renderComponent()
 
   expect(sendEventMock.mock.calls).toHaveLength(1)
-  expect(getEventArgument(sendEventMock.mock.calls[0]).event).toBe('pixel:listening')
+  expect(getEventArgument(sendEventMock.mock.calls[0]).event).toBe(
+    'pixel:listening'
+  )
 })
 
 test('should trigger past first events triggered before rendering on load', () => {
@@ -219,9 +221,10 @@ test('should not trigger duplicate events', () => {
 
   expect(sendEventMock).toHaveBeenCalledTimes(1)
 
-  fireLoadEvent()
-
   __pushEvent({ event: 'orderPlaced', data: 'foo' })
+
+  fireLoadEvent()
+  fireLoadEvent()
 
   expect(sendEventMock).toHaveBeenCalledTimes(3)
   expect(getEventArgument(sendEventMock.mock.calls[1]).event).toBe('pageView')

--- a/react/__tests__/PixelIFrame.test.tsx
+++ b/react/__tests__/PixelIFrame.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import React from 'react'
-import { render, fireEvent, wait, act } from '@vtex/test-tools/react'
+import { render, act } from '@vtex/test-tools/react'
 
 import PixelIFrame from '../PixelIFrame'
 import sendEvent from '../modules/sendEvent'
@@ -52,7 +52,7 @@ function getWindowFromNode(node: any) {
   } else {
     // no idea...
     throw new Error(
-      `Unable to find the "window" object for the given node. fireEvent currently supports firing events on DOM nodes, document, and window. Please file an issue with the code that's causing you to see this error: https://github.com/testing-library/dom-testing-library/issues/new`,
+      `Unable to find the "window" object for the given node. fireEvent currently supports firing events on DOM nodes, document, and window. Please file an issue with the code that's causing you to see this error: https://github.com/testing-library/dom-testing-library/issues/new`
     )
   }
 }
@@ -68,9 +68,11 @@ const renderComponent = () => {
     const message = new window.MessageEvent('message', {
       data: data ? data : 'pixel:ready:' + pixelName,
       origin: `https://master--storecomponents.myvtex.com/_v/public/tracking-frame/${pixelName}`,
-      source: iframe.contentWindow
+      source: iframe.contentWindow,
     })
-    act(() => { window.dispatchEvent(message) })
+    act(() => {
+      window.dispatchEvent(message)
+    })
   }
 
   return { ...helpers, pixelName, fireLoadEvent }

--- a/react/modules/sendEvent.tsx
+++ b/react/modules/sendEvent.tsx
@@ -1,6 +1,10 @@
 import { PixelData } from '../PixelContext'
 
-const sendEvent = (frameWindow: Window, data: PixelData) => {
+interface PixelCommunication {
+  event: 'pixel:listening'
+}
+
+const sendEvent = (frameWindow: Window, data: PixelData | PixelCommunication) => {
   frameWindow.postMessage(data, '*')
 }
 

--- a/react/modules/sendEvent.tsx
+++ b/react/modules/sendEvent.tsx
@@ -5,7 +5,10 @@ interface PixelCommunication {
   pixel: string
 }
 
-const sendEvent = (frameWindow: Window, data: PixelData | PixelCommunication) => {
+const sendEvent = (
+  frameWindow: Window,
+  data: PixelData | PixelCommunication
+) => {
   frameWindow.postMessage(data, '*')
 }
 

--- a/react/modules/sendEvent.tsx
+++ b/react/modules/sendEvent.tsx
@@ -2,6 +2,7 @@ import { PixelData } from '../PixelContext'
 
 interface PixelCommunication {
   event: 'pixel:listening'
+  pixel: string
 }
 
 const sendEvent = (frameWindow: Window, data: PixelData | PixelCommunication) => {

--- a/react/typings/vtex.render-runtime.d.ts
+++ b/react/typings/vtex.render-runtime.d.ts
@@ -4,6 +4,7 @@ declare module 'vtex.render-runtime' {
 
   export interface RuntimeContext {
     account: string
+    workspace: string
     page: string
     culture: {
       availableLocales: string[]

--- a/react/typings/waait.d.ts
+++ b/react/typings/waait.d.ts
@@ -1,3 +1,0 @@
-declare module 'waait' {
-  export default function wait(timeout: number): Promise<void>
-}


### PR DESCRIPTION
** Depends on this being merged first https://github.com/vtex-apps/google-analytics/pull/7 **

#### What is the purpose of this pull request?

This allows iframes to use cookies while blocking accessing parent context.

#### What problem is this solving?

Usage of cookies by pixels.

#### How should this be manually tested?

https://breno--storecomponents.myvtexdev.com/clothing/Shorts/Samsung?map=c%2Cc%2Cb

#### Screenshots or example usage

n/a

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
