### PR TITLE
Add new event type: productImpression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added new type of event, productImpression.
+
 ## [0.11.3] - 2019-05-14
 
 ### Fixed
@@ -24,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.11.1] - 2019-05-09
 
 ### Fixed
+
 - Export `usePixel` in `PixelContext`.
 
 ## [0.11.0] - 2019-05-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2019-05-17
+
 ### Added
 
 - Added new type of event, productImpression.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "pixel-manager",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "title": "VTEX Pixel Manager",
   "description": "The VTEX Pixel Manager App.",
   "builders": {

--- a/react/PixelContext.tsx
+++ b/react/PixelContext.tsx
@@ -5,6 +5,7 @@ type EventType =
   | 'homeView'
   | 'productView'
   | 'productClick'
+  | 'productImpression'
   | 'otherView'
   | 'categoryView'
   | 'departmentView'

--- a/react/PixelIFrame.tsx
+++ b/react/PixelIFrame.tsx
@@ -96,6 +96,7 @@ const PixelIFrame: React.FunctionComponent<Props> = ({ pixel }) => {
       pageView: pixelEventHandler,
       productClick: pixelEventHandler,
       productView: pixelEventHandler,
+      productImpression: pixelEventHandler,
       removeFromCart: pixelEventHandler,
     })
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
In order to send events to google analytics, this pr create a new pixel event type, the product impression. This event definition is different from the other's productView and productClick events.

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [X] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.

**Workspace**: https://persepolis--storecomponents.myvtex.com