### PR TITLE
Add installWebApp Event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `installWebApp` event.
 
 ## [1.1.4] - 2019-10-25
 ### Changed

--- a/react/PixelContext.tsx
+++ b/react/PixelContext.tsx
@@ -16,6 +16,7 @@ type EventType =
   | 'removeFromCart'
   | 'pageComponentInteraction'
   | 'orderPlaced'
+  | 'installWebApp'
 
 export interface PixelData {
   event?: EventType


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add installWebApp pixel event.

#### What problem is this solving?
We need to measure and show how much PWA features contributed to the overall user experience on VTEX stores.

#### How should this be manually tested?
[Workspace](https://pwaevents2--storecomponents.myvtex.com/checkout/orderPlaced/?og=949500478939)

> This app is setup with the [PWA Google Tag manager App](https://github.com/vtex-apps/pwa-gtm-pixel/pull/1), so you can check using the gtm dataLayer.

1. Click 'install' on install banner at the bottom of the page
2. Choose the option you desire on the A2HS prompt
3. Open the console, type `dataLayer` and check if the event was added

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.