### PR TITLE
Feature/export pixel event types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `PixelEventTypes` entrypoint that exports relevant types.
 
 ## [1.5.0] - 2020-12-10
 ### Added

--- a/react/PixelContext.tsx
+++ b/react/PixelContext.tsx
@@ -1,37 +1,7 @@
 import hoistNonReactStatics from 'hoist-non-react-statics'
 import React, { useContext, createContext, PureComponent } from 'react'
 
-type EventType =
-  | 'addToCart'
-  | 'cart'
-  | 'cartChanged'
-  | 'cartId'
-  | 'cartLoaded'
-  | 'categoryView'
-  | 'checkout'
-  | 'checkoutOption'
-  | 'departmentView'
-  | 'finishPayment'
-  | 'homeView'
-  | 'installWebApp'
-  | 'internalSiteSearchView'
-  | 'openDrawer'
-  | 'orderPlaced'
-  | 'otherView'
-  | 'pageComponentInteraction'
-  | 'pageInfo'
-  | 'pageView'
-  | 'productClick'
-  | 'productImpression'
-  | 'productView'
-  | 'removeFromCart'
-  | 'sendPayments'
-
-export interface PixelData {
-  id?: string
-  event?: EventType
-  [data: string]: unknown
-}
+import { PixelData } from './PixelEventTypes'
 
 interface PixelEvent extends Event {
   data: any
@@ -152,4 +122,9 @@ class PixelProvider extends PureComponent<Props> {
   }
 }
 
-export default { Pixel: withPixel, withPixel, PixelProvider, usePixel }
+export default {
+  Pixel: withPixel,
+  withPixel,
+  PixelProvider,
+  usePixel,
+}

--- a/react/PixelEventTypes.ts
+++ b/react/PixelEventTypes.ts
@@ -1,0 +1,31 @@
+export type EventName =
+  | 'addToCart'
+  | 'cart'
+  | 'cartChanged'
+  | 'cartId'
+  | 'cartLoaded'
+  | 'categoryView'
+  | 'checkout'
+  | 'checkoutOption'
+  | 'departmentView'
+  | 'finishPayment'
+  | 'homeView'
+  | 'installWebApp'
+  | 'internalSiteSearchView'
+  | 'openDrawer'
+  | 'orderPlaced'
+  | 'otherView'
+  | 'pageComponentInteraction'
+  | 'pageInfo'
+  | 'pageView'
+  | 'productClick'
+  | 'productImpression'
+  | 'productView'
+  | 'removeFromCart'
+  | 'sendPayments'
+
+export interface PixelData {
+  id?: string
+  event?: EventName
+  [data: string]: unknown
+}

--- a/react/usePixelEventCallback.ts
+++ b/react/usePixelEventCallback.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react'
 
-import { PixelData } from './PixelContext'
+import { PixelData } from './PixelEventTypes'
 
 export const shouldCallEventHandler = (
   pixelEventData: PixelData,


### PR DESCRIPTION
#### What is the purpose of this pull request?

Create a new entrypoint `PixelEventTypes` to enable relevant types to be easily imported by other apps.

#### How should this be manually tested?

These are the generated types for now (print taken during development of `vtex.minicart`):

![Screen Shot 2020-12-10 at 15 44 20](https://user-images.githubusercontent.com/27777263/101815632-93c1fc00-3afe-11eb-983b-c5da6ddaf4a6.png)

To import these, you would just need to write:

```ts
import { PixelEventTypes } from 'vtex.pixel-manager'
``` 

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
