### PR TITLE
Trivial: Adding promotionClick and promoView pixel events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - `promotionClick` and `promoView` pixel events
+
 ## [1.6.0] - 2020-12-11
 ### Added
 - `PixelEventTypes` entrypoint that exports relevant types.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Added
+- `promotionClick` and `promoView` pixel events
 ## [1.6.0] - 2020-12-11
 ### Added
 - `PixelEventTypes` entrypoint that exports relevant types.

--- a/react/PixelEventTypes.ts
+++ b/react/PixelEventTypes.ts
@@ -21,6 +21,8 @@ export type EventName =
   | 'productClick'
   | 'productImpression'
   | 'productView'
+  | 'promotionClick'
+  | 'promoView'
   | 'removeFromCart'
   | 'sendPayments'
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
This PR adds `promotionClick` and `promoView` event types.

#### How should this be manually tested?

[Workspace](https://icaroshopbycategory--storecomponents.myvtex.com/)

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
