### PR TITLE
including wishlist eventName type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Adding `removeToWishlist` to EventName type
 
 ## [1.8.0] - 2021-04-19
 ### Added

--- a/react/PixelEventTypes.ts
+++ b/react/PixelEventTypes.ts
@@ -25,6 +25,7 @@ export type EventName =
   | 'promotionClick'
   | 'promoView'
   | 'removeFromCart'
+  | 'removeToWishlist'
   | 'sendPayments'
   | 'newsletterSubscription'
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Include not mapped eventName used [here](https://github.com/vtex-apps/wish-list/blob/7a501ca198c8d3f614cf0631fb19c7f62a8699e7/react/AddProductBtn.tsx#L306)

#### What problem is this solving?
`Type '"removeToWishlist"' is not assignable to type 'EventName'` is appearing on vtex link

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/6241622/173858324-d955856e-3d23-4a96-9574-496d7fc06775.png)


#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
