### PR TITLE
Feat/ add new ga4 event names support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-+ ### Addedd
-+ - GA4 new event names:
-+ - - viewCart
-+ - - beginCheckout
-+ - - addPaymentInfo
-+ - - addShippingInfo
-+ - - addToWishlist
-+ - - share
-+ - - login
-+ - - search
-+ - - signup
-+ - - refund
+
+### Added
+- GA4 new event names:
+  - `viewCart`
+  - `beginCheckout`
+  - `addPaymentInfo`
+  - `addShippingInfo`
+  - `addToWishlist`
+  - `share`
+  - `login`
+  - `search`
+  - `signup`
+  - `refund`
+
 ## [1.8.0] - 2021-04-19
 ### Added
 - `productComparison` pixel event.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
++ ### Addedd
++ - GA4 new event names:
++ - - viewCart
++ - - beginCheckout
++ - - addPaymentInfo
++ - - addShippingInfo
++ - - addToWishlist
++ - - share
++ - - login
++ - - search
++ - - signup
++ - - refund
 ## [1.8.0] - 2021-04-19
 ### Added
 - `productComparison` pixel event.

--- a/react/PixelEventTypes.ts
+++ b/react/PixelEventTypes.ts
@@ -35,7 +35,7 @@ export type EventName =
   | 'share'
   | 'login'
   | 'search'
-  | 'signup'
+  | 'signUp'
   | 'refund'
 
 export interface PixelData {

--- a/react/PixelEventTypes.ts
+++ b/react/PixelEventTypes.ts
@@ -27,6 +27,16 @@ export type EventName =
   | 'removeFromCart'
   | 'sendPayments'
   | 'newsletterSubscription'
+  | 'viewCart'
+  | 'beginCheckout'
+  | 'addPaymentInfo'
+  | 'addShippingInfo'
+  | 'addToWishlist'
+  | 'share'
+  | 'login'
+  | 'search'
+  | 'signup'
+  | 'refund'
 
 export interface PixelData {
   id?: string


### PR DESCRIPTION
#### What is the purpose of this pull request?
Since Universal Analytics will be deprecated, we are migrating our [GTM app](https://github.com/vtex-apps/google-tag-manager) to support GA4 new version, and this new version had new events that need to be in our types list

#### What problem is this solving?
Adds new types to allow apps to use this events

#### How should this be manually tested?
* Change to this branch
* Link the version in the app that needs to call a new event push
* Check if the name of event are list in the function call

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [X] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
