### PR TITLE
feat: autocomplete dataLayer events

### DIFF
--- a/react/PixelEventTypes.ts
+++ b/react/PixelEventTypes.ts
@@ -1,6 +1,7 @@
 export type EventName =
   | 'addToCart'
   | 'cart'
+  | 'autocomplete'
   | 'cartChanged'
   | 'cartId'
   | 'cartLoaded'


### PR DESCRIPTION
#### What is the purpose of this pull request?

Enviar eventos de dentro do autocomplete para o dataLayer.

#### What problem is this solving?

O código atual já tinha uma estrutura inicial para enviar os eventos dentro do autocomplete, porém, esses eventos não estavam sendo enviados, como:
- Clique no termo de sugestões
- Clique no termo de histórico de busca
- Clique no produto
- etc

Com os ajustes, os seguintes eventos agora são disparados:

**top_search_click**: quando um dos termos mais buscados é clicado.
**history_click**: quando um dos termos do histórico de busca é clicado.
**search_suggestion_click**: quando é clicado em algum termo de sugestão.
**see_all_products_click**: quando é clicado na opção ver todos os produtos, se houver product-summary.
**productClick**: quando é clicado sobre algum produto.

**handleAutocompleteSearch**: descontinuei, pois não estava enviando eventos **search** e acabava sobrepondo qualquer um dos eventos acima, enviando os dados vazios.

#### How should this be manually tested?

**top_search_click**: clique no input da barra de busca e em seguida clique em um dos termos mais buscados.
**history_click**:  clique no input da barra de busca e em seguida clique em dos termos que você já pesquisou e que está no histórico de busca,
**search_suggestion_click**: clique no input da barra de busca e em seguida digite algum termo. Algumas sugestões de termos irão aparecer, clique em alguma delas.
**see_all_products_click**: clique no input da barra de busca e em seguida digite algum termo. Na shelf, clique em ver todos os produtos (caso tenha). 
**productClick**: clique no input da barra de busca e em seguida digite algum termo. Na shelf, clique sobre algum produto (caso tenha).

Essa PR também tem dependências de outras PRs:
https://github.com/vtex-apps/google-tag-manager/pull/153
https://github.com/vtex-apps/search/pull/203

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
